### PR TITLE
create new terminal using `executeCommand`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,3 +60,9 @@
 ### Added
 
 - Publish extension to Open VSX Registry
+
+## [0.0.10] - 2026-03-23
+
+### Changed
+
+- Create new Terminal using `executeCommand`.

--- a/README.md
+++ b/README.md
@@ -85,3 +85,7 @@ If you come across any other issue, or if you could improve this extension pleas
 ### 0.0.9
 
 - Publish extension to Open VSX Registry
+
+### 0.0.10
+
+- Create new Terminal using `executeCommand`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-toggle-terminal",
-    "version": "0.0.9",
+    "version": "0.0.10",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-toggle-terminal",
-            "version": "0.0.9",
+            "version": "0.0.10",
             "devDependencies": {
                 "@types/mocha": "^10.0.10",
                 "@types/node": "25.x",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "Toggle Terminal",
     "publisher": "krish-r",
     "description": "This extension adds a terminal toggle icon (shortcut) in the status bar.",
-    "version": "0.0.9",
+    "version": "0.0.10",
     "engines": {
         "vscode": "^1.100.0"
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,7 @@ export function activate({ subscriptions }: vscode.ExtensionContext) {
             // Create a terminal if it does not already exist
             if (vscode.window.terminals.length === 0) {
                 isTerminalVisible = false;
-                vscode.window.createTerminal();
+                vscode.commands.executeCommand("workbench.action.terminal.new");
             }
             toggleTerminal();
         })),


### PR DESCRIPTION
resolves #41 

- `vscode.window.createTerminal()`'s - `TerminalOptions` (`cwd`) does not accept variable reference from user configuration / setting.
- However, creating a new Terminal using the following command seems to respect `terminal.integrated.cwd` from user configuration / setting.
`vscode.commands.executeCommand("workbench.action.terminal.new");` 

Reference:
- https://code.visualstudio.com/docs/reference/variables-reference
- https://code.visualstudio.com/api/references/vscode-api#TerminalOptions

